### PR TITLE
Fix to #48 multi-file timestep issue

### DIFF
--- a/src/aavs_uv/io/aavs_hdf5_uvdata.py
+++ b/src/aavs_uv/io/aavs_hdf5_uvdata.py
@@ -151,6 +151,7 @@ def hdf5_to_pyuvdata(filename: str, yaml_config: str=None, telescope_name: str=N
     # Compute JD from unix time and LST - we can do this as we set an EarthLocation on t0 Time
     _t = np.arange(md['n_integrations'], dtype='float64') * md['tsamp'] + md['ts_start']
     _t += md['tsamp'] / 2 # Time array is based on center of integration, so add tdelt / 2 
+    _t += start_int *  md['tsamp']  # Add time offset if not reading from t0
 
     t = Time(_t, format='unix', location=telescope_earthloc)
     t0 = t[0]

--- a/tests/test_aavs_uv.py
+++ b/tests/test_aavs_uv.py
@@ -223,9 +223,14 @@ def test_max_int_start_int():
     assert np.allclose(uv0.data_array[0], uv.data_array[0])
     assert np.allclose(uv1.data_array[0], uv.data_array[32896])
 
+    # Confirm time step updates
+    dt = Time(uv1.time_array[0], format='jd') - Time(uv0.time_array[0], format='jd')
+    print(dt.sec, uv0.integration_time)
+    assert np.allclose(dt.sec, uv0.integration_time, atol=5e-5)
+
 if __name__ == "__main__":
-    #test0()
-    #test_compare()
-    #test_write()
-    #test_aavs2_2x500()
+    test0()
+    test_compare()
+    test_write()
+    test_aavs2_2x500()
     test_max_int_start_int()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -148,7 +148,6 @@ def test_parallel():
             os.remove("test.uvx5")
 
 if __name__ == "__main__":
-    test_dask()
     test_batch()
     test_context()
     test_phase_to_sun()


### PR DESCRIPTION
* **Improvement in Data Reading**
  An update made to how we read data in `aavs_hdf5_uvdata.py` file now conveniently adjusts for any time offset when it's not reading from the start (t0). This ensures we correctly align our data in reference to time, improving how our analytics work with time-series data.

* **Confirmation of Time Step Updates**
  A new provision has been added to our testing suite `test_aavs_uv.py`, which now confirms updates regarding time steps. This enhances the reliability and correctness of our software by catching any issues during the development process.

* **Code Clean-Up**
  A redundant function call, `test_dask()`, has been removed from the `tests/test_converter.py`. This cleaning-up makes our codebase leaner and more efficient, reducing unnecessary computation and making the programming flow clearer.